### PR TITLE
Reduce concrete text copies

### DIFF
--- a/tokenization_scorer/__init__.py
+++ b/tokenization_scorer/__init__.py
@@ -1,5 +1,5 @@
 from typing import Union, Generator, List
-import argparse
+import argparse, itertools
 import tqdm
 from .metrics import get_metric
 
@@ -12,18 +12,19 @@ def score(
     if type(text) == str:
         text = [l.split() for l in tqdm.tqdm(text.split("\n"))]
     else:
-        text = list(text)
-        if type(text[0]) != str:
+        # text = list(text)
+        text, peekable = itertools.tee(text)
+        if type(next(peekable)) != str:
             # flatten once more
-            text = [w for l in text for w in tqdm.tqdm(l)]
-        text = [l.rstrip("\n").split() for l in tqdm.tqdm(text)]
+            text = (w for l in text for w in tqdm.tqdm(l))
+        text = (l.rstrip("\n").split() for l in tqdm.tqdm(text))
 
     # cleanup (remove empty lines and words)
-    text = [
-        [w.strip() for w in l if w.strip()]
+    text = (
+        (w.strip() for w in l if w.strip())
         for l in text
-    ]
-    text = [l for l in text if l]
+    )
+    text = (l for l in text if l)
     score_val = get_metric(metric)(text, **kwargs)
 
     return score_val

--- a/tokenization_scorer/metrics.py
+++ b/tokenization_scorer/metrics.py
@@ -3,11 +3,11 @@ import numpy as np
 import sys
 
 def get_prob_distribution(text):
-    words_freqs = list(Counter((w for l in text for w in l)).most_common())
-    total_subwords = sum([x[1] for x in words_freqs])
+    words_freqs = Counter((w for l in text for w in l)).most_common()
+    total_subwords = sum(x[1] for x in words_freqs)
     freqs = [
         freq
-        for word, freq in words_freqs
+        for _, freq in words_freqs
     ]
     probs = [
         freq / total_subwords


### PR DESCRIPTION
Make most text transformations lazy.

I see a ~3x speedup on my machine on a 2M line input.

Before: 
```
Setting power to 3.0 (default)
Vocabulary size 279279
0.30303992094741333

real    0m24.331s
user    0m22.601s
sys     0m1.727s
```

After
```
Setting power to 3.0 (default)
Vocabulary size 279279
0.30303992094741333

real    0m8.411s
user    0m8.477s
sys     0m2.313s
```